### PR TITLE
Use rounding when quantizing weights (and activations)

### DIFF
--- a/bitmat/utils/bitmat.py
+++ b/bitmat/utils/bitmat.py
@@ -12,7 +12,7 @@ def terniarize(weights: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     dtype = weights.dtype
     scale = 1 / torch.max(weights.abs().mean(), torch.tensor(1e-5))
-    return torch.clamp((weights * scale).to(torch.int8), -1, 1), scale.to(dtype)
+    return torch.clamp((weights * scale).round().to(torch.int8), -1, 1), scale.to(dtype)
 
 def quantize_activations(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     """
@@ -20,7 +20,7 @@ def quantize_activations(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     dtype = x.dtype
     scale = (127 / torch.max(x.abs().max(dim=-1).values, torch.tensor(1e-5))).unsqueeze(-1)
-    return torch.clamp((x * scale), -127, 128).to(torch.int8), scale.to(dtype)
+    return torch.clamp((x * scale).round(), -127, 128).to(torch.int8), scale.to(dtype)
 
 
 class BitMat(torch.autograd.Function):


### PR DESCRIPTION
The bitnet paper uses rounding when quantizing activations. The current code just casts to int8. This has the effect of squashing any value between -1 and 1 (exclusive) to zero, so you lose a lot of expressiveness. For example, try

```python
>>> import torch
>>> x = [-1.2, -1, -0.9, -0.1, 0, 0.1, 0.9, 1, 1.2]
>>> torch.Tensor(x).to(torch.int8)
tensor([-1, -1,  0,  0,  0,  0,  0,  1,  1], dtype=torch.int8)
>>> torch.Tensor(x).round().to(torch.int8)
tensor([-1, -1, -1,  0,  0,  0,  1,  1,  1], dtype=torch.int8)
>>>
```


Whether you should use rounding when quantizing activations is less clear. I can't tell from the paper, and it's less important, but it seems reasonable.
