### PR TITLE
Optinal activation quant

### DIFF
--- a/bitmat/utils/bitmat.py
+++ b/bitmat/utils/bitmat.py
@@ -20,7 +20,7 @@ def quantize_activations(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     dtype = x.dtype
     scale = (127 / torch.max(x.abs().max(dim=-1).values, torch.tensor(1e-5))).unsqueeze(-1)
-    return torch.clamp((x * scale), -127, 128).to(torch.int8), scale.to(dtype)
+    return torch.clamp((x * scale), -128, 127).to(torch.int8), scale.to(dtype)
 
 
 class BitMat(torch.autograd.Function):


### PR DESCRIPTION
kernel is giving nan when activation are quantized in 8bit, adding way to optionally run quantize activations
+ activation quant range fix , -127, 128 => , -128, 127